### PR TITLE
chore: nativeWindowOpen is default true and will be removed with elec…

### DIFF
--- a/main.js
+++ b/main.js
@@ -209,7 +209,6 @@ function createJitsiMeetWindow() {
         webPreferences: {
             enableBlinkFeatures: 'WebAssemblyCSP',
             contextIsolation: false,
-            nativeWindowOpen: true,
             nodeIntegration: false,
             preload: path.resolve(basePath, './build/preload.js')
         }


### PR DESCRIPTION
…tron18 (#723)

nativeWindowOpen is default since Electron 15, and the parameter will be
removed with Electron 18, thus prep for this.

See https://github.com/electron/electron/blob/main/docs/breaking-changes.md#removed-nativewindowopen